### PR TITLE
Fix deployment: add base path secret and correct directory structure

### DIFF
--- a/.github/workflows/deploy-ssh.yml
+++ b/.github/workflows/deploy-ssh.yml
@@ -38,6 +38,8 @@ jobs:
           mv prelaunch.txt groups/
 
       - name: Build project
+        env:
+          SATVIS_BASE_PATH: ${{ secrets.SATVIS_BASE_PATH }}
         run: npm run build
 
       - name: Setup SSH
@@ -86,25 +88,27 @@ jobs:
           # Extract and deploy on server
           ssh -i ~/.ssh/deploy_key ${SSH_USER}@${SSH_HOST} bash -s << ENDSSH
             set -e
-            cd ${DEPLOY_PATH}
+            PARENT_DIR=\$(dirname ${DEPLOY_PATH})
+            DEPLOY_NAME=\$(basename ${DEPLOY_PATH})
+            cd "\$PARENT_DIR"
 
-            # Backup current deployment
-            if [ -d "current" ]; then
-              BACKUP_DIR="backup-\$(date +%Y%m%d-%H%M%S)"
-              mv current "\$BACKUP_DIR"
+            # Backup current deployment if it exists
+            if [ -d "\$DEPLOY_NAME" ]; then
+              BACKUP_DIR="\${DEPLOY_NAME}-backup-\$(date +%Y%m%d-%H%M%S)"
+              mv "\$DEPLOY_NAME" "\$BACKUP_DIR"
               echo "✓ Backed up current deployment to \$BACKUP_DIR"
 
               # Keep only last 5 backups
-              ls -dt backup-* 2>/dev/null | tail -n +6 | xargs -r rm -rf
+              ls -dt "\${DEPLOY_NAME}-backup-"* 2>/dev/null | tail -n +6 | xargs -r rm -rf
             fi
 
-            # Extract new deployment
-            mkdir -p current
-            tar -xzf satvis-deploy.tar.gz -C current/
-            rm satvis-deploy.tar.gz
+            # Create deployment directory and extract new deployment
+            mkdir -p "\$DEPLOY_NAME"
+            tar -xzf "\$DEPLOY_NAME/satvis-deploy.tar.gz" -C "\$DEPLOY_NAME/"
+            rm "\$DEPLOY_NAME/satvis-deploy.tar.gz"
 
             # Set correct permissions
-            chmod -R 755 current/
+            chmod -R 755 "\$DEPLOY_NAME/"
 
             echo "✓ Deployment completed successfully"
           ENDSSH
@@ -116,7 +120,7 @@ jobs:
           DEPLOY_PATH: ${{ secrets.SSH_DEPLOY_PATH }}
         run: |
           ssh -i ~/.ssh/deploy_key ${SSH_USER}@${SSH_HOST} bash -s << ENDVERIFY
-            if [ -f "${DEPLOY_PATH}/current/index.html" ]; then
+            if [ -f "${DEPLOY_PATH}/index.html" ]; then
               echo "✓ Verified: index.html exists"
               exit 0
             else

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -77,6 +77,7 @@ The SSH deployment workflow requires the following secrets to be configured in G
 | `SSH_DEPLOY_HOST` | Server hostname |
 | `SSH_DEPLOY_USER` | SSH username |
 | `SSH_DEPLOY_PATH` | Deployment directory path on server |
+| `SATVIS_BASE_PATH` | Base URL path for the application |
 
 ### Setting Up Secrets
 
@@ -108,9 +109,10 @@ Or manually append the public key to `~/.ssh/authorized_keys` on the server.
 2. Click **New repository secret**
 3. Add each required secret:
    - **SSH_DEPLOY_KEY**: Paste the **entire contents** of the private key file (`~/.ssh/satvis_deploy_key`)
-   - **SSH_DEPLOY_HOST**: Server hostname (e.g., `example.com`)
+   - **SSH_DEPLOY_HOST**: Server hostname
    - **SSH_DEPLOY_USER**: SSH username for authentication
    - **SSH_DEPLOY_PATH**: Absolute path to deployment directory on server
+   - **SATVIS_BASE_PATH**: Base URL path where the application is served
 
 ### Deployment Process
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,11 @@ const cesiumWidgetsSource = "node_modules/@cesium/widgets";
 const cesiumBaseUrl = "cesium";
 
 export default defineConfig({
-  base: process.env.GITHUB_ACTIONS ? "/satvis/" : "",
+  // Set base path based on deployment target
+  // - GitHub Pages: /satvis/
+  // - Production server: from SATVIS_BASE_PATH env var
+  // - Development: /
+  base: process.env.SATVIS_BASE_PATH || (process.env.GITHUB_ACTIONS ? "/satvis/" : ""),
   build: {
     sourcemap: true,
     chunkSizeWarningLimit: 1000,


### PR DESCRIPTION
Changes:
- Add SATVIS_BASE_PATH secret for configuring base URL path
- Update vite.config.js to use SATVIS_BASE_PATH environment variable
- Fix deployment to replace entire directory instead of deploying to /current subdirectory
- Backups now stored as {dirname}-backup-{timestamp} in parent directory
- Update verification to check correct path
- Update documentation with new secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)