### PR TITLE
Add step to show GitHub runner IP address

### DIFF
--- a/.github/workflows/deploy-ssh.yml
+++ b/.github/workflows/deploy-ssh.yml
@@ -12,6 +12,14 @@ jobs:
     environment:
       name: production
     steps:
+      - name: Show runner IP address
+        run: |
+          echo "GitHub Runner Public IP Address:"
+          curl -s https://api.ipify.org
+          echo ""
+          echo "Alternate check:"
+          curl -s https://checkip.amazonaws.com
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Purpose
Add a step to the deploy-ssh workflow to display the GitHub Actions runner's public IP address. This helps with:
- Identifying which IP ranges GitHub-hosted runners use
- Troubleshooting SSH connection issues
- Configuring firewall rules if needed

## Changes
- Added "Show runner IP address" step that runs before checkout
- Uses two different services (api.ipify.org and checkip.amazonaws.com) for reliability
- Displays IP address early in the workflow for easy visibility

## Testing
This will show the IP in the workflow logs whenever the deploy-ssh workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)