### PR TITLE
Fix pass highlights not appearing after time jumps >24h

### DIFF
--- a/src/modules/util/CesiumTimelineHelper.js
+++ b/src/modules/util/CesiumTimelineHelper.js
@@ -71,7 +71,7 @@ export class CesiumTimelineHelper {
     this.scheduleTimelineUpdate(viewer);
   }
 
-  static addHighlightRanges(viewer, ranges, satelliteName) {
+  static addHighlightRanges(viewer, ranges, satelliteName, options = {}) {
     if (!viewer.timeline) {
       return;
     }
@@ -80,9 +80,11 @@ export class CesiumTimelineHelper {
       return;
     }
 
-    // Get current timeline range - DO NOT modify it
-    const timelineStart = JulianDate.toDate(viewer.clock.startTime);
-    const timelineStop = JulianDate.toDate(viewer.clock.stopTime);
+    // Get VISIBLE timeline range (use timeline's zoomed view, not clock bounds)
+    // timeline._startJulian/_endJulian reflect the user's zoomed view
+    const timeline = viewer.timeline;
+    const timelineStart = timeline?._startJulian ? JulianDate.toDate(timeline._startJulian) : JulianDate.toDate(viewer.clock.startTime);
+    const timelineStop = timeline?._endJulian ? JulianDate.toDate(timeline._endJulian) : JulianDate.toDate(viewer.clock.stopTime);
 
     // Filter ranges to only those visible in current timeline (with some overlap)
     const timelineStartMs = timelineStart.getTime();
@@ -95,8 +97,9 @@ export class CesiumTimelineHelper {
       return rangeEnd >= timelineStartMs && rangeStart <= timelineStopMs;
     });
 
-    // Limit to 8 passes per satellite for performance
-    const maxPasses = 8;
+    // Limit to 8 passes per satellite for performance (unless skipPerSatelliteLimit is set)
+    // When caller has already done global prioritization, skip this limit
+    const maxPasses = options.skipPerSatelliteLimit ? visibleRanges.length : 8;
     const limitedRanges = visibleRanges.slice(0, maxPasses);
 
     limitedRanges.forEach((range) => {
@@ -211,9 +214,10 @@ export class CesiumTimelineHelper {
       return;
     }
 
-    // Get current timeline range - DO NOT modify it
-    const timelineStart = JulianDate.toDate(viewer.clock.startTime);
-    const timelineStop = JulianDate.toDate(viewer.clock.stopTime);
+    // Get VISIBLE timeline range (use timeline's zoomed view, not clock bounds)
+    const timeline = viewer.timeline;
+    const timelineStart = timeline?._startJulian ? JulianDate.toDate(timeline._startJulian) : JulianDate.toDate(viewer.clock.startTime);
+    const timelineStop = timeline?._endJulian ? JulianDate.toDate(timeline._endJulian) : JulianDate.toDate(viewer.clock.stopTime);
     const timelineStartMs = timelineStart.getTime();
     const timelineStopMs = timelineStop.getTime();
 

--- a/src/test/e2e/satellite-group-passes.spec.js
+++ b/src/test/e2e/satellite-group-passes.spec.js
@@ -12,6 +12,140 @@ import { waitForPassCalculation, pauseAnimation } from "./helpers/globe-interact
  * - Pass data structure and validity
  */
 
+/**
+ * Helper to convert JulianDate to Unix timestamp (seconds)
+ * @param {Object} julianDate - JulianDate object with dayNumber and secondsOfDay
+ * @returns {number} Unix timestamp in seconds
+ */
+function julianDateToUnixSeconds(julianDate) {
+  if (!julianDate) return null;
+  // Julian Day 2440587.5 = Unix epoch (Jan 1, 1970 00:00:00 UTC)
+  const unixDays = julianDate.dayNumber - 2440587.5;
+  return unixDays * 86400 + julianDate.secondsOfDay;
+}
+
+/**
+ * Helper to get current pass highlights from timeline
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<{highlights: Array, passCount: number}>}
+ */
+async function getPassHighlights(page) {
+  return page.evaluate(() => {
+    const viewer = window.cc?.viewer;
+    if (!viewer || !viewer.timeline) return { highlights: [], passCount: 0 };
+
+    const highlightRanges = viewer.timeline._highlightRanges || [];
+    // Pass highlights have priority 0 (_base = 0)
+    const passHighlights = highlightRanges.filter((h) => h._base === 0);
+
+    // Helper to convert JulianDate to Unix seconds (inline for page.evaluate)
+    const toUnixSeconds = (jd) => {
+      if (!jd) return null;
+      const unixDays = jd.dayNumber - 2440587.5;
+      return unixDays * 86400 + jd.secondsOfDay;
+    };
+
+    return {
+      highlights: passHighlights.map((h) => ({
+        // Note: Cesium highlight ranges use underscore-prefixed private properties
+        startSeconds: toUnixSeconds(h._start),
+        stopSeconds: toUnixSeconds(h._stop),
+        color: h._color?.toCssColorString?.(),
+      })),
+      passCount: passHighlights.length,
+    };
+  });
+}
+
+/**
+ * Helper to advance simulation time by specified hours
+ * @param {import('@playwright/test').Page} page
+ * @param {number} hours - Number of hours to advance
+ */
+async function advanceTimeByHours(page, hours) {
+  await page.evaluate((hrs) => {
+    const viewer = window.cc?.viewer;
+    if (!viewer?.clock) return;
+
+    // JulianDate stores time as dayNumber + secondsOfDay
+    // Add hours by adding to secondsOfDay (1 hour = 3600 seconds)
+    const additionalSeconds = hrs * 3600;
+
+    // Helper to advance a JulianDate by the given seconds
+    const advanceJulianDate = (jd) => {
+      let newSecondsOfDay = jd.secondsOfDay + additionalSeconds;
+      let newDayNumber = jd.dayNumber;
+
+      // Handle day overflow (86400 seconds per day)
+      while (newSecondsOfDay >= 86400) {
+        newSecondsOfDay -= 86400;
+        newDayNumber += 1;
+      }
+      while (newSecondsOfDay < 0) {
+        newSecondsOfDay += 86400;
+        newDayNumber -= 1;
+      }
+
+      const newTime = jd.clone();
+      newTime.dayNumber = newDayNumber;
+      newTime.secondsOfDay = newSecondsOfDay;
+      return newTime;
+    };
+
+    // Advance currentTime, startTime, and stopTime by the same amount
+    // This keeps the timeline window centered on the new current time
+    viewer.clock.currentTime = advanceJulianDate(viewer.clock.currentTime);
+    viewer.clock.startTime = advanceJulianDate(viewer.clock.startTime);
+    viewer.clock.stopTime = advanceJulianDate(viewer.clock.stopTime);
+
+    // Update timeline to reflect new bounds
+    const timeline = viewer.timeline;
+    if (timeline) {
+      // Update timeline bounds directly
+      timeline.zoomTo(viewer.clock.startTime, viewer.clock.stopTime);
+      timeline.updateFromClock();
+    }
+  }, hours);
+}
+
+/**
+ * Helper to trigger pass recalculation by simulating user interaction with timeline
+ * This dispatches the same event that ClockMonitor emits when a time jump is detected
+ * @param {import('@playwright/test').Page} page
+ */
+async function triggerPassRecalculation(page) {
+  // Reset the pass calculation state before triggering
+  await page.evaluate(() => {
+    if (window._passCalculationState) {
+      window._passCalculationState.completed = false;
+    }
+  });
+
+  // Dispatch the cesium:clockTimeJumped event that ClockMonitor would emit
+  // This triggers the same code path as a real user time jump
+  await page.evaluate(() => {
+    const viewer = window.cc?.viewer;
+    if (!viewer) return;
+
+    const currentTime = viewer.clock.currentTime;
+    const event = new CustomEvent("cesium:clockTimeJumped", {
+      detail: {
+        oldTime: currentTime,
+        newTime: currentTime,
+        jumpSeconds: 86400, // 24 hours
+        clockMultiplier: 1,
+        timestamp: Date.now(),
+      },
+    });
+
+    console.log("[Test] Dispatching cesium:clockTimeJumped event");
+    window.dispatchEvent(event);
+  });
+
+  // Note: The SatelliteManager has a 3-second debounce before triggering recalculation
+  // waitForPassCalculation will handle the waiting for the actual calculation to complete
+}
+
 test.describe("Satellite Group Pass Prediction", () => {
   test("should load Stations group, create ground station, and calculate passes", async ({ page }) => {
     // Load entire Stations group (all satellites from data/tle/groups/stations.txt)
@@ -341,6 +475,181 @@ test.describe("Satellite Group Pass Prediction", () => {
       - Pass calculation rate: ${(passCalculationRate * 100).toFixed(1)}%
       - First satellite: ${passData.firstSatelliteName} (${passData.firstSatellitePassCount} passes)
       - Satellites with passes: ${passData.satelliteNamesWithPasses?.slice(0, 5).join(", ")}${passData.satelliteNamesWithPasses?.length > 5 ? "..." : ""}
+    `);
+  });
+
+  test("should update timeline pass highlights when jumping forward in time", async ({ page }) => {
+    // Load Stations group and set up ground station
+    await page.goto("/?tags=Stations&hideLight=0&onlyLit=0");
+
+    // Wait for Cesium to be ready
+    await expect(page.locator("#cesiumContainer canvas").first()).toBeVisible({ timeout: 15000 });
+    await page.waitForFunction(
+      () => {
+        const viewer = window.cc?.viewer;
+        if (!viewer || !viewer.scene) return false;
+        return viewer.scene.globe && viewer.scene.globe._surface;
+      },
+      { timeout: 20000 },
+    );
+
+    // Wait for satellites to load
+    await page.waitForFunction(
+      () => {
+        const sats = window.cc?.sats?.satellites;
+        if (!sats || sats.length === 0) return false;
+        const createdSats = sats.filter((s) => s.created);
+        return createdSats.length >= 20;
+      },
+      { timeout: 30000 },
+    );
+
+    // Pause animation
+    await pauseAnimation(page);
+
+    // Create ground station by clicking on globe center
+    const groundStationButton = page
+      .locator("button.cesium-toolbar-button")
+      .filter({ has: page.locator(".svg-groundstation") })
+      .first();
+    await expect(groundStationButton).toBeVisible({ timeout: 5000 });
+    await groundStationButton.click();
+    await page.mouse.move(0, 0);
+
+    const pickOnGlobeLabel = page.locator('label.toolbarSwitch:has-text("Pick on globe")');
+    await expect(pickOnGlobeLabel).toBeVisible({ timeout: 10000 });
+    const pickOnGlobeCheckbox = pickOnGlobeLabel.locator('input[type="checkbox"]');
+    if (!(await pickOnGlobeCheckbox.isChecked())) {
+      await pickOnGlobeLabel.click();
+    }
+
+    const canvasBox = await page.evaluate(() => {
+      const canvas = document.querySelector("#cesiumContainer canvas");
+      if (!canvas) return null;
+      const rect = canvas.getBoundingClientRect();
+      return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+    });
+    expect(canvasBox).not.toBeNull();
+
+    await page.mouse.click(canvasBox.x + canvasBox.width * 0.5, canvasBox.y + canvasBox.height * 0.5);
+
+    // Wait for ground station
+    await page.waitForFunction(() => window.cc?.sats?.groundStations?.length > 0, { timeout: 10000 });
+
+    // Set simulation to current time
+    await page.evaluate(() => {
+      if (window.cc?.viewer?.clock && typeof window.Cesium !== "undefined") {
+        const testDate = new Date();
+        window.cc.viewer.clock.currentTime = window.Cesium.JulianDate.fromDate(testDate);
+        window.cc.viewer.clock.shouldAnimate = false;
+      }
+    });
+
+    // Select ground station to trigger pass calculation
+    await page.evaluate(() => {
+      const viewer = window.cc?.viewer;
+      const gs = window.cc?.sats?.groundStations?.[0];
+      if (viewer && gs?.components?.Groundstation) {
+        viewer.selectedEntity = gs.components.Groundstation;
+      }
+    });
+
+    // Wait for initial pass calculation
+    await waitForPassCalculation(page, { timeout: 60000 });
+
+    // ===== STEP 1: Check initial pass highlights =====
+    const initialHighlights = await getPassHighlights(page);
+    console.log(`Initial highlights: ${initialHighlights.passCount} passes`);
+
+    expect(initialHighlights.passCount).toBeGreaterThan(0);
+
+    // Store initial highlight times for comparison
+    const initialHighlightTimes = new Set(initialHighlights.highlights.map((h) => `${h.startSeconds}-${h.stopSeconds}`));
+
+    // ===== STEP 2: Jump 24 hours forward =====
+    console.log("Jumping 24 hours forward...");
+    await advanceTimeByHours(page, 24);
+    await triggerPassRecalculation(page);
+
+    // Wait for pass recalculation after time jump
+    // Use waitForEvent: true because passes already exist - we need to wait for the NEW calculation
+    await waitForPassCalculation(page, { timeout: 60000, waitForEvent: true });
+
+    // Get highlights after first 24h jump
+    const highlightsAfter24h = await getPassHighlights(page);
+    console.log(`After 24h jump: ${highlightsAfter24h.passCount} passes`);
+
+    // Verify we have pass highlights after jump
+    expect(highlightsAfter24h.passCount).toBeGreaterThan(0);
+
+    // Check that we have NEW highlights (not the same as initial)
+    const after24hHighlightTimes = new Set(highlightsAfter24h.highlights.map((h) => `${h.startSeconds}-${h.stopSeconds}`));
+
+    // Count how many highlights are new (not in initial set)
+    let newHighlightsAfter24h = 0;
+    for (const time of after24hHighlightTimes) {
+      if (!initialHighlightTimes.has(time)) {
+        newHighlightsAfter24h++;
+      }
+    }
+
+    console.log(`New highlights after 24h jump: ${newHighlightsAfter24h} (out of ${highlightsAfter24h.passCount})`);
+
+    // At least some highlights should be new after jumping 24h
+    // (passes from 24h ago should no longer be visible in timeline)
+    expect(newHighlightsAfter24h).toBeGreaterThan(0);
+
+    // ===== STEP 3: Jump another 24 hours forward (48h total) =====
+    console.log("Jumping another 24 hours forward (48h total)...");
+    await advanceTimeByHours(page, 24);
+    await triggerPassRecalculation(page);
+
+    // Wait for pass recalculation
+    // Use waitForEvent: true because passes already exist - we need to wait for the NEW calculation
+    await waitForPassCalculation(page, { timeout: 60000, waitForEvent: true });
+
+    // Get highlights after second 24h jump (48h total)
+    const highlightsAfter48h = await getPassHighlights(page);
+    console.log(`After 48h total: ${highlightsAfter48h.passCount} passes`);
+
+    // Verify we have pass highlights after second jump
+    expect(highlightsAfter48h.passCount).toBeGreaterThan(0);
+
+    // Check that we have NEW highlights compared to after first jump
+    const after48hHighlightTimes = new Set(highlightsAfter48h.highlights.map((h) => `${h.startSeconds}-${h.stopSeconds}`));
+
+    // Count how many highlights are new compared to after first 24h jump
+    let newHighlightsAfter48h = 0;
+    for (const time of after48hHighlightTimes) {
+      if (!after24hHighlightTimes.has(time)) {
+        newHighlightsAfter48h++;
+      }
+    }
+
+    console.log(`New highlights after 48h (vs 24h): ${newHighlightsAfter48h} (out of ${highlightsAfter48h.passCount})`);
+
+    // At least some highlights should be new after jumping another 24h
+    expect(newHighlightsAfter48h).toBeGreaterThan(0);
+
+    // Verify that highlights from 48h later are completely different from initial
+    let overlappingWithInitial = 0;
+    for (const time of after48hHighlightTimes) {
+      if (initialHighlightTimes.has(time)) {
+        overlappingWithInitial++;
+      }
+    }
+
+    console.log(`Highlights at 48h overlapping with initial: ${overlappingWithInitial}`);
+
+    // After 48 hours, most (if not all) highlights should be different from initial
+    // The timeline typically shows ~24h of passes, so 48h later should have mostly new passes
+    const overlapPercentage = overlappingWithInitial / highlightsAfter48h.passCount;
+    expect(overlapPercentage).toBeLessThan(0.5); // Less than 50% overlap expected
+
+    console.log(`Timeline highlight update test completed successfully:
+      - Initial highlights: ${initialHighlights.passCount}
+      - After 24h: ${highlightsAfter24h.passCount} (${newHighlightsAfter24h} new)
+      - After 48h: ${highlightsAfter48h.passCount} (${newHighlightsAfter48h} new vs 24h, ${overlappingWithInitial} overlap with initial)
     `);
   });
 });


### PR DESCRIPTION
- Use visible timeline bounds (timeline._startJulian/_endJulian) instead of clock bounds for filtering passes - fixes highlights not appearing when user zooms out timeline and clicks to jump time
- Prioritize passes globally by proximity to current simulation time instead of per-satellite, ensuring closest passes are shown first
- Add skipPerSatelliteLimit option to CesiumTimelineHelper to avoid 8-pass-per-satellite limit when global prioritization is done
- Clear satellite passInterval before recalculating to force fresh pass calculation after time jumps
- Dispatch satvis:passCalculationComplete event after timeline change recalculation for E2E test synchronization
- Add waitForEvent option to waitForPassCalculation helper
- Add E2E test for timeline highlight updates after 24h and 48h jumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)