### PR TITLE
fix: Validate stale TLEs and filter decayed satellites from selection

### DIFF
--- a/src/modules/SatelliteManager.js
+++ b/src/modules/SatelliteManager.js
@@ -628,6 +628,10 @@ export class SatelliteManager {
   get taglist() {
     const taglist = {};
     this.satellites.forEach((sat) => {
+      // Skip stale satellites (decayed or TLE too old for reliable propagation)
+      if (sat.props.isStale) {
+        return;
+      }
       sat.props.tags.forEach((tag) => {
         (taglist[tag] = taglist[tag] || []).push(sat.props.name);
       });
@@ -736,6 +740,10 @@ export class SatelliteManager {
    * @returns {boolean} true if the satellite is enabled
    */
   satIsActive(sat) {
+    // Stale satellites (decayed or TLE too old) should never be active
+    if (sat.props.isStale) {
+      return false;
+    }
     const enabledByTag = sat.props.tags.some((tag) => this.#enabledTags.has(tag));
     const enabledByName = this.#enabledSatellites.has(sat.props.name);
     return enabledByTag || enabledByName;

--- a/src/test/fixtures/tle-data.js
+++ b/src/test/fixtures/tle-data.js
@@ -3,13 +3,28 @@
  * All TLEs use real orbital elements for accurate testing
  */
 
-// ISS (3-line format with name) - December 2018
+// ISS (3-line format with name) - December 2018 (STALE - used for staleness tests)
 export const ISS_TLE = `ISS (ZARYA)
 1 25544U 98067A   18342.69352573  .00002284  00000-0  41838-4 0  9992
 2 25544  51.6407 229.0798 0005166 124.8351 329.3296 15.54069892145658`;
 
-// ISS (2-line format without name) - Same epoch
+// ISS (2-line format without name) - Same epoch (STALE)
 export const ISS_TLE_NO_NAME = `1 25544U 98067A   18342.69352573  .00002284  00000-0  41838-4 0  9992
+2 25544  51.6407 229.0798 0005166 124.8351 329.3296 15.54069892145658`;
+
+// ISS with dynamically generated fresh epoch - always recent for tests
+// Generates epoch as "today" to ensure TLE is never flagged as stale
+function generateFreshEpoch() {
+  const now = new Date();
+  const year = now.getUTCFullYear() % 100; // 2-digit year
+  const startOfYear = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+  const dayOfYear = Math.floor((now - startOfYear) / (24 * 60 * 60 * 1000)) + 1;
+  const fractionOfDay = (now.getUTCHours() * 3600 + now.getUTCMinutes() * 60 + now.getUTCSeconds()) / 86400;
+  return `${year.toString().padStart(2, "0")}${(dayOfYear + fractionOfDay).toFixed(8).padStart(12, "0")}`;
+}
+
+export const ISS_TLE_FRESH = `ISS (ZARYA)
+1 25544U 98067A   ${generateFreshEpoch()}  .00002284  00000-0  41838-4 0  9992
 2 25544  51.6407 229.0798 0005166 124.8351 329.3296 15.54069892145658`;
 
 // ISS with updated orbital elements (simulates TLE data refresh)


### PR DESCRIPTION
SGP4 returns garbage position data (28,000+ km altitude) for high-drag satellites propagated far beyond their decay date, without setting an error flag. This causes satellites to appear in wrong locations.

Changes:
- Add TLE staleness detection based on epoch age and drag coefficients
- Add position validation to catch unreasonable SGP4 results
- Filter stale satellites from selection list and prevent activation
- Log warnings for stale TLEs on load

Fixes issue where satellite 45110 from classfd.tle appeared at 28,600 km altitude instead of expected ~460 km LEO orbit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)