### PR TITLE
fix: Prevent crash when viewing pre-launch satellites in past time

### DIFF
--- a/src/modules/SatelliteComponentCollection.js
+++ b/src/modules/SatelliteComponentCollection.js
@@ -540,10 +540,15 @@ export class SatelliteComponentCollection extends CesiumComponentCollection {
   }
 
   createOrbitPolylinePrimitive() {
+    const positions = this.props.getSampledPositionsForNextOrbit(this.viewer.clock.currentTime);
+    // Need at least 2 positions for a polyline (e.g., pre-launch satellites may have no valid positions)
+    if (!positions || positions.length < 2) {
+      return;
+    }
     const primitive = new Primitive({
       geometryInstances: new GeometryInstance({
         geometry: new PolylineGeometry({
-          positions: this.props.getSampledPositionsForNextOrbit(this.viewer.clock.currentTime),
+          positions,
           width: 2,
           arcType: ArcType.NONE,
           // granularity: CesiumMath.RADIANS_PER_DEGREE * 10,
@@ -567,9 +572,14 @@ export class SatelliteComponentCollection extends CesiumComponentCollection {
 
   createOrbitPolylineGeometry() {
     // Currently unused
+    const positions = this.props.getSampledPositionsForNextOrbit(this.viewer.clock.currentTime);
+    // Need at least 2 positions for a polyline (e.g., pre-launch satellites may have no valid positions)
+    if (!positions || positions.length < 2) {
+      return;
+    }
     const geometryInstance = new GeometryInstance({
       geometry: new PolylineGeometry({
-        positions: this.props.getSampledPositionsForNextOrbit(this.viewer.clock.currentTime),
+        positions,
         width: 2,
         arcType: ArcType.NONE,
         // granularity: CesiumMath.RADIANS_PER_DEGREE * 10,

--- a/src/modules/SatelliteProperties.js
+++ b/src/modules/SatelliteProperties.js
@@ -129,8 +129,13 @@ export class SatelliteProperties {
 
   getSampledPositionsForNextOrbit(start, reference = "inertial", loop = true) {
     const end = JulianDate.addSeconds(start, this.orbit.orbitalPeriod * 60, new JulianDate());
-    const positions = this.sampledPosition[reference].getRawValues(start, end);
-    if (loop) {
+    const rawPositions = this.sampledPosition[reference].getRawValues(start, end);
+    // Filter out undefined positions (e.g., pre-launch satellites that are hidden)
+    const positions = rawPositions.filter((p) => p !== undefined);
+    if (positions.length === 0) {
+      return [];
+    }
+    if (loop && positions.length > 0) {
       // Readd the first position to the end of the array to close the loop
       return [...positions, positions[0]];
     }


### PR DESCRIPTION
## Summary
- Fix crash when viewing pre-launch satellites and navigating to times before TLE epoch
- Handle edge case where orbit polyline geometry requires at least 2 positions

## Changes
- Filter undefined positions in `getSampledPositionsForNextOrbit` 
- Add position count check before creating `PolylineGeometry`
- Skip orbit creation gracefully when insufficient positions

## Test plan
- [x] Unit tests pass
- [x] E2E tests pass
- [x] Manual test: Load a pre-launch satellite, go back in time before TLE epoch - no crash

🤖 Generated with [Claude Code](https://claude.ai/code)